### PR TITLE
Bump rawbson to 0.2.0

### DIFF
--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "rawbson"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6432289a014978713cb802e4c651e9a99a422e7eac7e614fb8d7bdb232ae77"
+checksum = "ffb82470e3941b2d3b68c66c633eeebedaa3a289078eef151fb7b26f9e2b8c0e"
 dependencies = [
  "bson",
  "chrono",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -22,7 +22,7 @@ no_proto = { path = "../no_proto_rs" }
 prost = "0.7.0"
 protobuf = "2.18.1"
 rand = "0.7.3"
-rawbson = "0.1.0"
+rawbson = "0.2.0"
 rkyv = "0.3.0"
 rmp = "0.8.9"
 rmp-serde = "0.15.1"

--- a/bench/src/run_bench_rawbson.rs
+++ b/bench/src/run_bench_rawbson.rs
@@ -5,8 +5,7 @@ use flate2::Compression;
 use flate2::write::ZlibEncoder;
 use std::time::{SystemTime};
 use rawbson::{
-    DocRef,
-    DocBuf,
+    Doc,
     elem,
 };
 use bson::*;
@@ -99,7 +98,7 @@ impl RawBSONBench {
         let start = SystemTime::now();
 
         for _x in 0..LOOPS {
-            let container = DocRef::new(&buffer[..]).unwrap();
+            let container = Doc::new(&buffer[..]).unwrap();
 
             assert_eq!(container.get_str("location").unwrap().unwrap(), "http://arstechnica.com");
         }
@@ -115,7 +114,7 @@ impl RawBSONBench {
         let start = SystemTime::now();
 
         for _x in 0..LOOPS {
-            let container = DocRef::new(&buffer[..]).unwrap();
+            let container = Doc::new(&buffer[..]).unwrap();
 
             assert_eq!(container.get_str("location").unwrap().unwrap(), "http://arstechnica.com");
             assert_eq!(container.get_i32("fruit").unwrap().unwrap(), 2i32);
@@ -134,14 +133,14 @@ impl RawBSONBench {
                 let sibling = foobar.get_document("sibling").unwrap().unwrap();
                 assert_eq!(sibling.get_i32("time").unwrap().unwrap(), 123456 + (x as i32));
                 assert_eq!(sibling.get_f64("ratio").unwrap().unwrap(), 3.14159f64);
-                assert_eq!(sibling.get_i32("size").unwrap().unwrap(), 10000 + (x as i32));               
+                assert_eq!(sibling.get_i32("size").unwrap().unwrap(), 10000 + (x as i32));
             }
 
             assert!(loops == 3);
         }
 
         let time = SystemTime::now().duration_since(start).expect("Time went backwards");
-        println!("Raw BSON:    {:>9.0} ops/ms {:.2}", LOOPS as f64 / time.as_millis() as f64, (base as f64 / time.as_micros() as f64));    
+        println!("Raw BSON:    {:>9.0} ops/ms {:.2}", LOOPS as f64 / time.as_millis() as f64, (base as f64 / time.as_micros() as f64));
         format!("{:>6.0}", LOOPS as f64 / time.as_millis() as f64)
     }
 }


### PR DESCRIPTION
Replaces `DocRef<'a>` with `&'a Doc`, and reduces compile time.  (I accidentally made proptest a dependency instead of a dev-dependency in v0.1.*).

Performance should be comparable.