### PR TITLE
Add `postcard` crate to comparison

### DIFF
--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -36,6 +36,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68803225a7b13e47191bab76f2687382b60d259e8cf37f6e1893658b84bb9479"
 
 [[package]]
+name = "as-slice"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4d1c23475b74e3672afa8c2be22040b8b7783ad9b461021144ed10a46bb0e6"
+dependencies = [
+ "generic-array 0.12.3",
+ "generic-array 0.13.2",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +97,7 @@ dependencies = [
  "json",
  "messagepack-rs",
  "no_proto",
+ "postcard",
  "prost",
  "protobuf",
  "rand 0.7.3",
@@ -229,7 +242,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -287,6 +300,24 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -307,10 +338,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "heapless"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.2",
+ "hash32",
+ "serde",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -495,6 +548,23 @@ name = "ord_subset"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7ce14664caf5b27f5656ff727defd68ae1eb75ef3c4d95259361df1eb376bef"
+
+[[package]]
+name = "postcard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ba0d1b66f31fb374fede892eb4b0818ea819d5e7bc587345ce50a6949e782"
+dependencies = [
+ "heapless",
+ "postcard-cobs",
+ "serde",
+]
+
+[[package]]
+name = "postcard-cobs"
+version = "0.1.5-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
 
 [[package]]
 name = "ppv-lite86"
@@ -831,6 +901,12 @@ name = "smallvec"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strum"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -19,6 +19,7 @@ flexbuffers = "0.2.1"
 json = "0.12.4"
 messagepack-rs = "0.8.0"
 no_proto = { path = "../no_proto_rs" }
+postcard = { version = "0.5.2", features = ["use-std"] }
 prost = "0.7.0"
 protobuf = "2.18.1"
 rand = "0.7.3"
@@ -30,5 +31,8 @@ rmpv = "0.4.6"
 serde = "1.0.118"
 serde_json = "1.0.61"
 
-[target.x86_64-apple-darwin]
+[target.x86_64-apple-darwin.build]
+rustflags = ["-Ctarget-cpu=native"]
+
+[target.x86_64-unknown-linux-gnu.build]
 rustflags = ["-Ctarget-cpu=native"]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -31,8 +31,5 @@ rmpv = "0.4.6"
 serde = "1.0.118"
 serde_json = "1.0.61"
 
-[target.x86_64-apple-darwin.build]
-rustflags = ["-Ctarget-cpu=native"]
-
-[target.x86_64-unknown-linux-gnu.build]
+[target.x86_64-apple-darwin]
 rustflags = ["-Ctarget-cpu=native"]

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -10,6 +10,7 @@ use crate::run_bench_no_proto::NoProtoBench;
 use crate::run_bench_flatbuffers::FlatBufferBench;
 use crate::run_bench_bson::BSONBench;
 use crate::run_bench_bincode::BincodeBench;
+use crate::run_bench_postcard::PostcardBench;
 use crate::run_bench_avro::AvroBench;
 use crate::run_bench_prost::ProstBench;
 use crate::run_bench_flexbuffers::FlexBench;
@@ -20,13 +21,13 @@ mod bench_fb;
 mod bench_pb;
 extern crate protobuf;
 extern crate flatbuffers;
-#[macro_use] 
+#[macro_use]
 extern crate json;
 extern crate bson;
 extern crate rmp;
 extern crate serde;
 extern crate bincode;
-#[macro_use] 
+#[macro_use]
 extern crate abomonation;
 
 
@@ -38,6 +39,7 @@ mod run_bench_messagepack_rs;
 mod run_bench_json;
 mod run_bench_bson;
 mod run_bench_bincode;
+mod run_bench_postcard;
 mod run_bench_prost;
 mod run_bench_avro;
 mod run_bench_flexbuffers;
@@ -62,6 +64,7 @@ fn main() {
     let np_lib    = "       [no_proto](https://crates.io/crates/no_proto)      ";
     let fb_lib    = "    [flatbuffers](https://crates.io/crates/flatbuffers)   ";
     let bn_lib    = "        [bincode](https://crates.io/crates/bincode)       ";
+    let pc_lib    = "       [postcard](https://crates.io/crates/postcard)      ";
     let pb_lib    = "       [protobuf](https://crates.io/crates/protobuf)      ";
     let msg_lib   = "            [rmp](https://crates.io/crates/rmp)           ";
     let json_lib  = "           [json](https://crates.io/crates/json)          ";
@@ -80,6 +83,7 @@ fn main() {
     let np_size = NoProtoBench::size_bench();
     let fb_size = FlatBufferBench::size_bench();
     let bn_size = BincodeBench::size_bench();
+    let pc_size = PostcardBench::size_bench();
     let pb_size = ProtocolBufferBench::size_bench();
     let msg_size = MessagePackBench::size_bench();
     let json_size = JSONBench::size_bench();
@@ -94,10 +98,11 @@ fn main() {
     let json2_size = SerdeJSONBench::size_bench();
 
     println!("\n======== ENCODE BENCHMARK ========");
-    
+
     let (base, np_enc) = NoProtoBench::encode_bench().unwrap();
     let fb_enc = FlatBufferBench::encode_bench(base);
     let bn_enc = BincodeBench::encode_bench(base);
+    let pc_enc = PostcardBench::encode_bench(base);
     let pb_enc = ProtocolBufferBench::encode_bench(base);
     let msg_enc = MessagePackBench::encode_bench(base);
     let json_enc = JSONBench::encode_bench(base);
@@ -116,6 +121,7 @@ fn main() {
     let (base, np_dec) = NoProtoBench::decode_bench().unwrap();
     let fb_dec = FlatBufferBench::decode_bench(base);
     let bn_dec = BincodeBench::decode_bench(base);
+    let pc_dec = PostcardBench::decode_bench(base);
     let pb_dec = ProtocolBufferBench::decode_bench(base);
     let msg_dec = MessagePackBench::decode_bench(base);
     let json_dec = JSONBench::decode_bench(base);
@@ -134,6 +140,7 @@ fn main() {
     let (base, np_dec1) = NoProtoBench::decode_one_bench().unwrap();
     let fb_dec1 = FlatBufferBench::decode_one_bench(base);
     let bn_dec1 = BincodeBench::decode_one_bench(base);
+    let pc_dec1 = PostcardBench::decode_one_bench(base);
     let pb_dec1 = ProtocolBufferBench::decode_one_bench(base);
     let msg_dec1 = MessagePackBench::decode_one_bench(base);
     let json_dec1 = JSONBench::decode_one_bench(base);
@@ -152,6 +159,7 @@ fn main() {
     let (base, np_up) = NoProtoBench::update_bench().unwrap();
     let fb_up = FlatBufferBench::update_bench(base);
     let bn_up = BincodeBench::update_bench(base);
+    let pc_up = PostcardBench::update_bench(base);
     let pb_up = ProtocolBufferBench::update_bench(base);
     let msg_up = MessagePackBench::update_bench(base);
     let json_up = JSONBench::update_bench(base);
@@ -191,6 +199,8 @@ fn main() {
     println!("//! | {} |  {} |     {} |   {} |   {} |          {} |         {} |", fb_lib, fb_enc, fb_dec, fb_dec1, fb_up, fb_size.0, fb_size.1);
     println!("//! | Bincode                                                    |         |            |          |          |              |             |");
     println!("//! | {} |  {} |     {} |   {} |   {} |          {} |         {} |", bn_lib, bn_enc, bn_dec, bn_dec1, bn_up, bn_size.0, bn_size.1);
+    println!("//! | Postcard                                                   |         |            |          |          |              |             |");
+    println!("//! | {} |  {} |     {} |   {} |   {} |          {} |         {} |", pc_lib, pc_enc, pc_dec, pc_dec1, pc_up, pc_size.0, pc_size.1);
     println!("//! | Protocol Buffers                                           |         |            |          |          |              |             |");
     println!("//! | {} |  {} |     {} |   {} |   {} |          {} |         {} |", pb_lib, pb_enc, pb_dec, pb_dec1, pb_up, pb_size.0, pb_size.1);
     println!("//! | {} |  {} |     {} |   {} |   {} |          {} |         {} |", pro_lib, pro_enc, pro_dec, pro_dec1, pro_up, pro_size.0, pro_size.1);

--- a/bench/src/run_bench_postcard.rs
+++ b/bench/src/run_bench_postcard.rs
@@ -1,0 +1,169 @@
+use crate::LOOPS;
+
+
+use std::io::prelude::*;
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+use std::time::{SystemTime};
+use serde::{Serialize, Deserialize};
+use postcard;
+
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+enum Fruit {
+    Apples, Pears, Bananas
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+struct Bar {
+  time: i32,
+  ratio: f32,
+  size: u16
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+struct FooBar<'fb> {
+  sibling: Bar,
+  name: &'fb str,
+  rating: f64,
+  postfix: char
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+struct FooBarContainer<'con> {
+  list: Vec<FooBar<'con>>,
+  initialized: bool,
+  fruit: Fruit,
+  location: &'con str
+}
+
+pub struct PostcardBench();
+
+impl PostcardBench {
+
+    pub fn size_bench() -> (usize, usize) {
+
+        let encoded = Self::encode_single();
+
+        let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
+        e.write(&encoded[..]).unwrap();
+        let compressed = e.finish().unwrap();
+
+        println!("Postcard:    size: {}b, zlib: {}b", encoded.len(), compressed.len());
+        return (encoded.len(), compressed.len())
+    }
+
+    pub fn encode_bench(base: u128) -> String {
+        let start = SystemTime::now();
+
+        for _x in 0..LOOPS {
+            let buffer = Self::encode_single();
+            assert_eq!(buffer.len(), 128);
+        }
+
+        let time = SystemTime::now().duration_since(start).expect("Time went backwards");
+        println!("Postcard:    {:>9.0} ops/ms {:.2}", LOOPS as f64 / time.as_millis() as f64, (base as f64 / time.as_micros() as f64));
+        format!("{:>6.0}", LOOPS as f64 / time.as_millis() as f64)
+    }
+
+    #[inline(always)]
+    fn encode_single() -> Vec<u8> {
+
+        let mut vector: Vec<FooBar> = Vec::new();
+
+        for x in 0..3 {
+
+            let bar = Bar {
+                time: 123456 + (x as i32),
+                ratio: 3.14159 + (x as f32),
+                size: 10000 + (x as u16)
+            };
+            let foobar = FooBar {
+                sibling: bar,
+                name: "Hello, world!",
+                rating: 3.1415432432445543543 + (x as f64),
+                postfix: '!'
+            };
+            vector.push(foobar);
+        }
+
+        let foobar_c = FooBarContainer {
+            location: "http://arstechnica.com",
+            fruit: Fruit::Apples,
+            initialized: true,
+            list: vector
+        };
+
+        postcard::to_stdvec(&foobar_c).unwrap()
+    }
+
+    pub fn update_bench(base: u128) -> String {
+        let buffer = Self::encode_single();
+
+        let start = SystemTime::now();
+
+        for _x in 0..LOOPS {
+            let mut decoded: FooBarContainer = postcard::from_bytes(&buffer[..]).unwrap();
+
+            decoded.list[0].name = "bob";
+
+            let encoded = postcard::to_stdvec(&decoded).unwrap();
+
+            assert_eq!(encoded.len(), 118);
+        }
+
+        let time = SystemTime::now().duration_since(start).expect("Time went backwards");
+        println!("Postcard:    {:>9.0} ops/ms {:.2}", LOOPS as f64 / time.as_millis() as f64, (base as f64 / time.as_micros() as f64));
+        format!("{:>6.0}", LOOPS as f64 / time.as_millis() as f64)
+    }
+
+    pub fn decode_one_bench(base: u128) -> String {
+        let buffer = Self::encode_single();
+
+        let start = SystemTime::now();
+
+        for _x in 0..LOOPS {
+            let decoded: FooBarContainer = postcard::from_bytes(&buffer[..]).unwrap();
+            assert_eq!(decoded.location, "http://arstechnica.com");
+        }
+
+        let time = SystemTime::now().duration_since(start).expect("Time went backwards");
+        println!("Postcard:    {:>9.0} ops/ms {:.2}", LOOPS as f64 / time.as_millis() as f64, (base as f64 / time.as_micros() as f64));
+        format!("{:>6.0}", LOOPS as f64 / time.as_millis() as f64)
+    }
+
+    pub fn decode_bench(base: u128) -> String {
+        let mut buffer = Self::encode_single();
+
+        let start = SystemTime::now();
+
+        for _x in 0..LOOPS {
+            let decoded: FooBarContainer = postcard::from_bytes(&buffer[..]).unwrap();
+
+            let mut loops = 0;
+
+            decoded.list.iter().enumerate().for_each(|(x, foobar)| {
+                loops += 1;
+                let old_bar = &foobar.sibling;
+
+                assert_eq!(old_bar.time, 123456 + (x as i32));
+                assert_eq!(old_bar.ratio, 3.14159 + (x as f32));
+                assert_eq!(old_bar.size, 10000 + (x as u16));
+
+                assert_eq!(foobar.name, "Hello, world!");
+                assert_eq!(foobar.rating, 3.1415432432445543543 + (x as f64));
+                assert_eq!(foobar.postfix, '!');
+            });
+
+            assert!(loops == 3);
+
+            assert_eq!(decoded.location, "http://arstechnica.com");
+            assert_eq!(decoded.fruit, Fruit::Apples);
+            assert_eq!(decoded.initialized, true);
+        }
+
+        let time = SystemTime::now().duration_since(start).expect("Time went backwards");
+        println!("Postcard:    {:>9.0} ops/ms {:.2}", LOOPS as f64 / time.as_millis() as f64, (base as f64 / time.as_micros() as f64));
+        format!("{:>6.0}", LOOPS as f64 / time.as_millis() as f64)
+    }
+}


### PR DESCRIPTION
Hey! I have a crate called [postcard](https://docs.rs/postcard), which is aimed at embedded/WASM use cases, and has a format/style similar to `bincode`.

Here are the numbers I got locally:

```text
    Finished release [optimized] target(s) in 8.82s
     Running `target/release/bench`
NoProto:     setup: 0.011
Avro:     setup: 0.096
Flatbuffers:  setup: 0.002

========= SIZE BENCHMARK =========
NoProto:     size: 209b, zlib: 167b
Flatbuffers: size: 264b, zlib: 181b
Bincode:     size: 163b, zlib: 129b
Postcard:    size: 128b, zlib: 119b
Protobuf:    size: 154b, zlib: 141b
MessagePack: size: 311b, zlib: 193b
JSON:        size: 439b, zlib: 184b
BSON:        size: 414b, zlib: 216b
Prost:       size: 154b, zlib: 142b
Avro:        size: 702b, zlib: 337b
Flexbuffers: size: 490b, zlib: 309b
Abomonation: size: 261b, zlib: 162b
Rkyv:        size: 180b, zlib: 153b
Raw BSON:    size: 414b, zlib: 216b
MessagePack: size: 296b, zlib: 187b
Serde JSON:  size: 446b, zlib: 198b

======== ENCODE BENCHMARK ========
NoProto:           668 ops/ms 1.00
Flatbuffers:      2451 ops/ms 3.67
Bincode:          7353 ops/ms 10.96
Postcard:         3861 ops/ms 5.76
Protobuf:         1100 ops/ms 1.65
MessagePack:       684 ops/ms 1.03
JSON:              595 ops/ms 0.89
BSON:              158 ops/ms 0.24
Prost:            1397 ops/ms 2.09
Avro:              175 ops/ms 0.26
Flexbuffers:       326 ops/ms 0.49
Abomonation:      4762 ops/ms 7.10
Rkyv:             3344 ops/ms 5.00
Raw BSON:          173 ops/ms 0.26
MessagePack:       234 ops/ms 0.35
Serde JSON:        853 ops/ms 1.28

======== DECODE BENCHMARK ========
NoProto:           684 ops/ms 1.00
Flatbuffers:      7937 ops/ms 11.56
Bincode:          4386 ops/ms 6.41
Postcard:         4386 ops/ms 6.40
Protobuf:         1422 ops/ms 2.08
MessagePack:       508 ops/ms 0.74
JSON:              458 ops/ms 0.67
BSON:              151 ops/ms 0.22
Prost:            2203 ops/ms 3.21
Avro:               64 ops/ms 0.09
Flexbuffers:       419 ops/ms 0.61
Abomonation:     52632 ops/ms 75.43
Rkyv:            34483 ops/ms 49.16
Raw BSON:          706 ops/ms 1.03
MessagePack:       228 ops/ms 0.33
Serde JSON:        521 ops/ms 0.76

====== DECODE ONE BENCHMARK ======
NoProto:         18519 ops/ms 1.00
Flatbuffers:    111111 ops/ms 5.54
Bincode:          4505 ops/ms 0.25
Postcard:         4545 ops/ms 0.25
Protobuf:         1464 ops/ms 0.08
MessagePack:       626 ops/ms 0.03
JSON:              551 ops/ms 0.03
BSON:              156 ops/ms 0.01
Prost:            2217 ops/ms 0.12
Avro:               67 ops/ms 0.00
Flexbuffers:     16129 ops/ms 0.88
Abomonation:    166667 ops/ms 9.05
Rkyv:           333333 ops/ms 15.00
Raw BSON:        12500 ops/ms 0.68
MessagePack:       266 ops/ms 0.01
Serde JSON:        521 ops/ms 0.03

====== UPDATE ONE BENCHMARK ======
NoProto:          8696 ops/ms 1.00
Flatbuffers:      1805 ops/ms 0.21
Bincode:          2959 ops/ms 0.34
Postcard:         2066 ops/ms 0.24
Protobuf:          577 ops/ms 0.07
MessagePack:       255 ops/ms 0.03
JSON:              403 ops/ms 0.05
BSON:              119 ops/ms 0.01
Prost:             932 ops/ms 0.11
Avro:               44 ops/ms 0.01
Flexbuffers:       193 ops/ms 0.02
Abomonation:      4348 ops/ms 0.50
Rkyv:             2833 ops/ms 0.33
Raw BSON:          125 ops/ms 0.01
MessagePack:       157 ops/ms 0.02
Serde JSON:        327 ops/ms 0.04



//! | Format / Lib                                               | Encode  | Decode All | Decode 1 | Update 1 | Size (bytes) | Size (Zlib) |
//! |------------------------------------------------------------|---------|------------|----------|----------|--------------|-------------|
//! | **Runtime Libs**                                           |         |            |          |          |              |             |
//! | *NoProto*                                                  |         |            |          |          |              |             |
//! |        [no_proto](https://crates.io/crates/no_proto)       |     668 |        684 |    18519 |     8696 |          209 |         167 |
//! | Apache Avro                                                |         |            |          |          |              |             |
//! |         [avro-rs](https://crates.io/crates/avro-rs)        |     175 |         64 |       67 |       44 |          702 |         337 |
//! | FlexBuffers                                                |         |            |          |          |              |             |
//! |     [flexbuffers](https://crates.io/crates/flexbuffers)    |     326 |        419 |    16129 |      193 |          490 |         309 |
//! | JSON                                                       |         |            |          |          |              |             |
//! |            [json](https://crates.io/crates/json)           |     595 |        458 |      551 |      403 |          439 |         184 |
//! |      [serde_json](https://crates.io/crates/serde_json)     |     853 |        521 |      521 |      327 |          446 |         198 |
//! | BSON                                                       |         |            |          |          |              |             |
//! |            [bson](https://crates.io/crates/bson)           |     158 |        151 |      156 |      119 |          414 |         216 |
//! |         [rawbson](https://crates.io/crates/rawbson)        |     173 |        706 |    12500 |      125 |          414 |         216 |
//! | MessagePack                                                |         |            |          |          |              |             |
//! |             [rmp](https://crates.io/crates/rmp)            |     684 |        508 |      626 |      255 |          311 |         193 |
//! |  [messagepack-rs](https://crates.io/crates/messagepack-rs) |     234 |        228 |      266 |      157 |          296 |         187 |
//! | **Compiled Libs**                                          |         |            |          |          |              |             |
//! | Flatbuffers                                                |         |            |          |          |              |             |
//! |     [flatbuffers](https://crates.io/crates/flatbuffers)    |    2451 |       7937 |   111111 |     1805 |          264 |         181 |
//! | Bincode                                                    |         |            |          |          |              |             |
//! |         [bincode](https://crates.io/crates/bincode)        |    7353 |       4386 |     4505 |     2959 |          163 |         129 |
//! | Postcard                                                   |         |            |          |          |              |             |
//! |        [postcard](https://crates.io/crates/postcard)       |    3861 |       4386 |     4545 |     2066 |          128 |         119 |
//! | Protocol Buffers                                           |         |            |          |          |              |             |
//! |        [protobuf](https://crates.io/crates/protobuf)       |    1100 |       1422 |     1464 |      577 |          154 |         141 |
//! |           [prost](https://crates.io/crates/prost)          |    1397 |       2203 |     2217 |      932 |          154 |         142 |
//! | Abomonation                                                |         |            |          |          |              |             |
//! |     [abomonation](https://crates.io/crates/abomonation)    |    4762 |      52632 |   166667 |     4348 |          261 |         162 |
//! | Rkyv                                                       |         |            |          |          |              |             |
//! |            [rkyv](https://crates.io/crates/rkyv)           |    3344 |      34483 |   333333 |     2833 |          180 |         153 |
```

Thanks for putting these benchmarks together!